### PR TITLE
Add missing generic using statement

### DIFF
--- a/src/Avalon.Api/Services/UserService.cs
+++ b/src/Avalon.Api/Services/UserService.cs
@@ -1,5 +1,6 @@
 using Avalon.Core;
 using Avalon.Domain;
+using System.Collections.Generic;
 
 namespace Avalon.Api.Services
 {


### PR DESCRIPTION
## Summary
- ensure `UserService` has `System.Collections.Generic`
- verified `System.Collections.Generic` is present in the remaining files

## Testing
- `dotnet build Avalon.sln -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1b7b1bc48331b2d555ee42052065